### PR TITLE
[Bug Fix] create data after user and lp creation

### DIFF
--- a/app/models/loyalty_program.rb
+++ b/app/models/loyalty_program.rb
@@ -1,25 +1,26 @@
 class LoyaltyProgram < ApplicationRecord
+    after_create :create_loyalty_program_data
 
-    def valid_membership(id)
-        if membership_regex
-            if id.match(membership_regex)
-                puts "Match found!"
-                return true
-            else
-                puts "FAILEDDDD"
-                return false
-            end
-        else
-          puts "No Valid Regex"
-          return true
-        end
+  def valid_membership(id)
+    if membership_regex
+      if id.match(membership_regex)
+        puts 'Match found!'
+        true
+      else
+        puts 'FAILEDDDD'
+        false
+      end
+    else
+      puts 'No Valid Regex'
+      true
     end
-  after_create :create_loyalty_program_data
+  end
 
+  private
   # create loyalty program data for all users
   def create_loyalty_program_data
     User.all.each do |user|
-      LoyaltyProgramDatum.create(account_id: user.account.id, loyalty_program_id: self.id)
+      LoyaltyProgramDatum.create(account_id: user.account.id, loyalty_program_id: id)
     end
   end
 end

--- a/app/models/loyalty_program.rb
+++ b/app/models/loyalty_program.rb
@@ -14,4 +14,12 @@ class LoyaltyProgram < ApplicationRecord
           return true
         end
     end
+  after_create :create_loyalty_program_data
+
+  # create loyalty program data for all users
+  def create_loyalty_program_data
+    User.all.each do |user|
+      LoyaltyProgramDatum.create(account_id: user.account.id, loyalty_program_id: self.id)
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
 
     # for each loyalty program, create loyalty program data
     loyalty_programs.each do |loyalty_program|
-      LoyaltyProgramDatum.create(account_id: user.account.id, loyalty_program_id: loyalty_program.id)
+      LoyaltyProgramDatum.create(account_id: account.id, loyalty_program_id: loyalty_program.id)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_one :account, :dependent => :destroy
-  after_save :create_account
+  has_one :account, dependent: :destroy
+  after_save :create_account, :create_loyalty_program_data
 
   private
 
@@ -16,5 +16,17 @@ class User < ApplicationRecord
     # get points from loyalty program data
     # loyalty_program_data.points
     User.find(@user_id).account.loyalty_program_data.where(loyalty_program_id: 1).first.points
+  end
+
+  def create_loyalty_program_data
+    # create all loyalty program data for current user
+
+    # get all loyalty programs
+    loyalty_programs = LoyaltyProgram.all
+
+    # for each loyalty program, create loyalty program data
+    loyalty_programs.each do |loyalty_program|
+      LoyaltyProgramDatum.create(account_id: user.account.id, loyalty_program_id: loyalty_program.id)
+    end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,5 +25,7 @@
   txn = Transaction.create(loyalty_program_datum_id: i, amount: 100, created_at: '2000-01-01 02:00:00', status: 'pending',
                            account_id: i)
 
-  # loyalty_program_data = LoyaltyProgramDatum.create(account_id: i, loyalty_program_id: i)
+  # loyalty_program_data = LoyaltyProgramDatum.create(account_id: 1, loyalty_program_id: 1)
 end
+
+puts 'Seeding done!'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,5 +25,5 @@
   txn = Transaction.create(loyalty_program_datum_id: i, amount: 100, created_at: '2000-01-01 02:00:00', status: 'pending',
                            account_id: i)
 
-  loyalty_program_data = LoyaltyProgramDatum.create(account_id: i, loyalty_program_id: i)
+  # loyalty_program_data = LoyaltyProgramDatum.create(account_id: i, loyalty_program_id: i)
 end

--- a/spec/controllers/loyalty_program_data_controller_spec.rb
+++ b/spec/controllers/loyalty_program_data_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe LoyaltyProgramDataController, type: :controller do
+  let(:user) do
+    FactoryBot.create(:user)
+  end
+
+  describe 'creation' do
+    it 'can be created' do
+      expect(user).to be_valid
+      expect(User.count).to eq(1)
+      expect(User.first.name).to eq(user.name)
+    end
+  end
+
+  # TODO : still not too sure how to write test to test account creation
+end

--- a/spec/controllers/transaction_controller.rb
+++ b/spec/controllers/transaction_controller.rb
@@ -1,26 +1,26 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe TransactionController, type: :controller do
+# RSpec.describe TransactionController, type: :controller do
   
-  let(:user) do
-    User.create(
-      email: 'foo@bar.net',
-      name: 'baz',
-      lastname: 'qux',
-      password: 'chicken',
-      password_confirmation: 'chicken'
-    )
-  end
+#   let(:user) do
+#     User.create(
+#       email: 'foo@bar.net',
+#       name: 'baz',
+#       lastname: 'qux',
+#       password: 'chicken',
+#       password_confirmation: 'chicken'
+#     )
+#   end
 
 
-  describe 'creation' do
-    it 'can be created' do
-      expect(user).to be_valid
-      expect(User.count).to eq(1)
-      expect(User.first.name).to eq(user.name)
-    end
-  end
+#   describe 'creation' do
+#     it 'can be created' do
+#       expect(user).to be_valid
+#       expect(User.count).to eq(1)
+#       expect(User.first.name).to eq(user.name)
+#     end
+#   end
 
-  # TODO : still not too sure how to write test to test account creation
+#   # TODO : still not too sure how to write test to test account creation
   
-end
+# end

--- a/spec/models/loyalty_program_datum_spec.rb
+++ b/spec/models/loyalty_program_datum_spec.rb
@@ -11,35 +11,38 @@ RSpec.describe LoyaltyProgramDatum, type: :model do
 
   describe '#create' do
     it 'should create a loyalty_program_datum' do
-      debugger
+      lp_id = lp.id
+      account_id = user.account.id
       initial_count = LoyaltyProgramDatum.count
 
-      LoyaltyProgramDatum.create(account_id: user.account.id,
-                                 loyalty_program_id: lp.id)
+      LoyaltyProgramDatum.create(account_id: account_id,
+                                 loyalty_program_id: lp_id)
       expect(LoyaltyProgramDatum.count).to eq(initial_count + 1)
     end
   end
 
   # TODO: Refer to https://github.com/50-003-ESC-Gang/Loyalty-Points/issues/86
   context 'when loyalty program is created' do
-    xit 'should create a loyalty program data for all user' do
+    it 'should create a loyalty program data for all user' do
       # initial_count = LoyaltyProgramDatum.count
-      lp = LoyaltyProgram.create(name: 'Test Loyalty Program')
+      lp_id = 'id-test-id'
+      lp = LoyaltyProgram.create(loyalty_program_id: lp_id)
 
       user = User.all
 
       # check if loyalty program data is created for all users
       user.each do |curr_user|
         # check if loyalty program data is created for each user
-        expect(LoyaltyProgramDatum.where(account_id: curr_user.account.id, loyalty_program_id: lp.id).count).to eq(1)
+        expect(LoyaltyProgramDatum.where(account_id: curr_user.account.id, loyalty_program_id: lp_id).count).to eq(1)
       end
     end
   end
 
   context 'when user is created' do
-    xit 'should create all loyalty program data for the user' do
+    it 'should create all loyalty program data for the user' do
       initial_count = LoyaltyProgramDatum.count
-      lp = LoyaltyProgram.create(name: 'Test Loyalty Program')
+      lp_id = 'id-test-id'
+      lp = LoyaltyProgram.create(loyalty_program_id: lp_id)
 
       user = User.all
 

--- a/spec/models/loyalty_program_datum_spec.rb
+++ b/spec/models/loyalty_program_datum_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe LoyaltyProgramDatum, type: :model do
     FactoryBot.create(:loyalty_program)
   end
 
-  context 'when happy case for create loyalty_program_datum' do
+  describe '#create' do
     it 'should create a loyalty_program_datum' do
+      debugger
       initial_count = LoyaltyProgramDatum.count
 
       LoyaltyProgramDatum.create(account_id: user.account.id,
@@ -20,14 +21,36 @@ RSpec.describe LoyaltyProgramDatum, type: :model do
   end
 
   # TODO: Refer to https://github.com/50-003-ESC-Gang/Loyalty-Points/issues/86
-  # context 'when loyalty program is created' do
-  #   xit 'should create a loyalty program data for user' do
-  #     expect(LoyaltyProgramDatum.count).to eq(0)
-  #     debugger
-  #     FactoryBot.create(:loyalty_program)
+  context 'when loyalty program is created' do
+    xit 'should create a loyalty program data for all user' do
+      # initial_count = LoyaltyProgramDatum.count
+      lp = LoyaltyProgram.create(name: 'Test Loyalty Program')
 
-  #     expect(LoyaltyProgramDatum.count).to eq(1)
-  #     expect(LoyaltyProgramDatum.first.loyalty_program_id).to eq(lp.loyalty_program_id)
-  #   end
-  # end
+      user = User.all
+
+      # check if loyalty program data is created for all users
+      user.each do |curr_user|
+        # check if loyalty program data is created for each user
+        expect(LoyaltyProgramDatum.where(account_id: curr_user.account.id, loyalty_program_id: lp.id).count).to eq(1)
+      end
+    end
+  end
+
+  context 'when user is created' do
+    xit 'should create all loyalty program data for the user' do
+      initial_count = LoyaltyProgramDatum.count
+      lp = LoyaltyProgram.create(name: 'Test Loyalty Program')
+
+      user = User.all
+
+      # check if loyalty program data is created for all users
+      user.each do |curr_user|
+        # check if loyalty program data is created for each user
+        expect(LoyaltyProgramDatum.where(account_id: curr_user.account.id, loyalty_program_id: lp.id).count).to eq(1)
+      end
+
+      # expect(LoyaltyProgramDatum.count).to eq(1)
+      # expect(LoyaltyProgramDatum.first.loyalty_program_id).to eq(lp.loyalty_program_id)
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/50-003-ESC-Gang/Loyalty-Points/issues/86

When user create an account, we should create all loyalty program data for the user.

When we create loyalty program data, we should create loyalty program data for all users.

